### PR TITLE
fix: Updated jsonwebtoken version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT License",
       "dependencies": {
         "axios": "^1.6.7",
-        "jsonwebtoken": "8.5.1",
+        "jsonwebtoken": "^9.0.2",
         "platform": "1.3.6",
         "uuid": "8.3.2"
       },
@@ -2784,9 +2784,10 @@
       }
     },
     "node_modules/jsonwebtoken": {
-      "version": "8.5.1",
-      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-8.5.1.tgz",
-      "integrity": "sha512-XjwVfRS6jTMsqYs0EsuJ4LGxXV14zQybNd4L2r0UvbVnSF9Af8x7p5MzbJ90Ioz/9TI41/hTCvznF/loiSzn8w==",
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.2.tgz",
+      "integrity": "sha512-PRp66vJ865SSqOlgqS8hujT5U4AOgMfhrwYIuIhfKaoSCZcirrmASQr8CX7cUg+RMih+hgznrjp99o+W4pJLHQ==",
+      "license": "MIT",
       "dependencies": {
         "jws": "^3.2.2",
         "lodash.includes": "^4.3.0",
@@ -2797,19 +2798,23 @@
         "lodash.isstring": "^4.0.1",
         "lodash.once": "^4.0.0",
         "ms": "^2.1.1",
-        "semver": "^5.6.0"
+        "semver": "^7.5.4"
       },
       "engines": {
-        "node": ">=4",
-        "npm": ">=1.4.28"
+        "node": ">=12",
+        "npm": ">=6"
       }
     },
     "node_modules/jsonwebtoken/node_modules/semver": {
-      "version": "5.7.2",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
-      "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
+      "version": "7.6.3",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
+      "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
+      "license": "ISC",
       "bin": {
-        "semver": "bin/semver"
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/jwa": {

--- a/package.json
+++ b/package.json
@@ -27,17 +27,17 @@
     "test:cov": "jest --coverage"
   },
   "dependencies": {
-    "jsonwebtoken": "8.5.1",
-    "uuid": "8.3.2",
+    "axios": "^1.6.7",
+    "jsonwebtoken": "^9.0.2",
     "platform": "1.3.6",
-    "axios": "^1.6.7"
+    "uuid": "8.3.2"
   },
   "devDependencies": {
-    "@types/jsonwebtoken": "^8.5.1",
-    "@types/uuid": "^8.3.2",
-    "@types/platform": "^1.3.6",
-    "@types/node": "^12.11.5",
     "@types/jest": "29.4.0",
+    "@types/jsonwebtoken": "^8.5.1",
+    "@types/node": "^12.11.5",
+    "@types/platform": "^1.3.6",
+    "@types/uuid": "^8.3.2",
     "jest": "29.4.2",
     "jest-junit": "^14.0.0",
     "ts-jest": "29.0.5",


### PR DESCRIPTION
## Pull Request Description

I updated the jsonwebtoken version to v9.0.2 which addresses the following vulnerabilities:

> jsonwebtoken vulnerable to signature validation bypass due to insecure default algorithm in jwt.verify() - https://github.com/advisories/GHSA-qwph-4952-7xr6
> jsonwebtoken unrestricted key type could lead to legacy keys usage  - https://github.com/advisories/GHSA-8cf7-32gw-wr33
> jsonwebtoken's insecure implementation of key retrieval function could lead to Forgeable Public/Private Tokens from RSA to HMAC - https://github.com/advisories/GHSA-hjrf-2m68-5959


## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Chore / Documentation
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [X] Locally tested against Fireblocks API

## Checklist:

- [X] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have added corresponding labels to the PR
