### PR TITLE
Add «pending enrichment» transaction status

### DIFF
--- a/docs/models/Transaction.md
+++ b/docs/models/Transaction.md
@@ -39,6 +39,8 @@
 
 * `PendingAmlScreening` (value: `'PENDING_AML_SCREENING'`)
 
+* `PendingEnrichment` (value: `'PENDING_ENRICHMENT'`)
+
 * `Cancelling` (value: `'CANCELLING'`)
 
 * `Cancelled` (value: `'CANCELLED'`)

--- a/models/transaction.ts
+++ b/models/transaction.ts
@@ -60,6 +60,7 @@ export const TransactionStateEnum = {
     Completed: 'COMPLETED',
     PartiallyCompleted: 'PARTIALLY_COMPLETED',
     PendingAmlScreening: 'PENDING_AML_SCREENING',
+    PendingEnrichment: 'PENDING_ENRICHMENT',
     Cancelling: 'CANCELLING',
     Cancelled: 'CANCELLED',
     Rejected: 'REJECTED',


### PR DESCRIPTION
## Pull Request Description

Added a new transaction status `PENDING_ENRICHMENT` to `TransactionStateEnum`. This status represents transactions that are awaiting enrichment before proceeding to the next state.  

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

- [x] Locally tested against Fireblocks API

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have added corresponding labels to the PR
