### PR TITLE
fix(deps): bump axios to ^1.16.0 (CVE-2026-44492)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "20.0.0",
       "license": "MIT License",
       "dependencies": {
-        "axios": "^1.15.2",
+        "axios": "^1.16.0",
         "jsonwebtoken": "^9.0.2",
         "platform": "1.3.6",
         "uuid": "8.3.2"

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "jsonwebtoken": "^9.0.2",
     "uuid": "8.3.2",
     "platform": "1.3.6",
-    "axios": "^1.15.2"
+    "axios": "^1.16.0"
   },
   "devDependencies": {
     "@types/jsonwebtoken": "^9.0.2",


### PR DESCRIPTION
## Pull Request Description

Bumps `axios` from `^1.15.2` to `^1.16.0` to address SSRF vulnerability
[SNYK-JS-AXIOS-17111062](https://security.snyk.io/vuln/SNYK-JS-AXIOS-17111062) / CVE-2026-44492.

Affected axios versions: `>=1.0.0 <1.16.0`. The current SDK dependency
can resolve to `1.15.x`, which Snyk flags in consumer CI pipelines.

Fixes #186 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] Ran `npm install` and verified `npm ls axios` resolves to >= 1.16.0
- [ ] Locally tested against Fireblocks API (not applicable for dep bump)

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation (N/A)
- [ ] Any dependent changes have been merged and published in downstream modules (N/A)